### PR TITLE
Re-construct DateComponents in UTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 *.iml
 .idea/
 
+# VSCode
+.project
+.settings
+.classpath
+
 # fastlane
 #
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 

--- a/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/PrayerTimes.java
@@ -35,7 +35,7 @@ public class PrayerTimes {
 
   private PrayerTimes(Coordinates coordinates, Date date, CalculationParameters parameters) {
     this.coordinates = coordinates;
-    this.dateComponents = DateComponents.from(date);
+    this.dateComponents = DateComponents.fromUTC(date);
     this.calculationParameters = parameters;
 
     Date tempFajr = null;

--- a/adhan/src/main/java/com/batoulapps/adhan/SunnahTimes.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/SunnahTimes.java
@@ -19,7 +19,7 @@ public class SunnahTimes {
         final Date tomorrowPrayerTimesDate = CalendarUtil.add(currentPrayerTimesDate, 1, Calendar.DATE);
         final PrayerTimes tomorrowPrayerTimes =
                 new PrayerTimes(prayerTimes.coordinates,
-                        DateComponents.from(tomorrowPrayerTimesDate),
+                        DateComponents.fromUTC(tomorrowPrayerTimesDate),
                         prayerTimes.calculationParameters);
 
         final int nightDurationInSeconds =

--- a/adhan/src/main/java/com/batoulapps/adhan/data/CalendarUtil.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/data/CalendarUtil.java
@@ -41,7 +41,7 @@ public class CalendarUtil {
   }
 
   /**
-   * Add an offset to a particular day
+   * Add the specified amount of a unit of time to a particular date
    * @param when the original date
    * @param amount the amount to add
    * @param field the field to add it to (from {@link java.util.Calendar}'s fields).

--- a/adhan/src/main/java/com/batoulapps/adhan/data/DateComponents.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/data/DateComponents.java
@@ -3,6 +3,7 @@ package com.batoulapps.adhan.data;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class DateComponents {
   public final int year;
@@ -25,5 +26,18 @@ public class DateComponents {
     this.year = year;
     this.month = month;
     this.day = day;
+  }
+
+  /**
+   * Convenience method that returns a DateComponents from a given
+   * Date that was constructed from UTC based components
+   * @param date the date
+   * @return the DateComponents (according to UTC)
+   */
+  public static DateComponents fromUTC(Date date) {
+    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(date);
+    return new DateComponents(calendar.get(Calendar.YEAR),
+        calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
   }
 }

--- a/adhan/src/main/java/com/batoulapps/adhan/data/TimeComponents.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/data/TimeComponents.java
@@ -27,9 +27,11 @@ public class TimeComponents {
     this.seconds = seconds;
   }
 
-  public Date dateComponents(Date date) {
+  public Date dateComponents(DateComponents date) {
     Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
-    calendar.setTime(date);
+    calendar.set(Calendar.YEAR, date.year);
+    calendar.set(Calendar.MONTH, date.month - 1);
+    calendar.set(Calendar.DAY_OF_MONTH, date.day);
     calendar.set(Calendar.HOUR_OF_DAY, 0);
     calendar.set(Calendar.MINUTE, minutes);
     calendar.set(Calendar.SECOND, seconds);

--- a/adhan/src/main/java/com/batoulapps/adhan/internal/SolarTime.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/internal/SolarTime.java
@@ -1,11 +1,7 @@
 package com.batoulapps.adhan.internal;
 
 import com.batoulapps.adhan.Coordinates;
-
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
+import com.batoulapps.adhan.data.DateComponents;
 
 public class SolarTime {
 
@@ -19,19 +15,12 @@ public class SolarTime {
   private final SolarCoordinates nextSolar;
   private double approximateTransit;
 
-  public SolarTime(Date today, Coordinates coordinates) {
-    Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
-    calendar.setTime(today);
+  public SolarTime(DateComponents today, Coordinates coordinates) {
+    final double julianDate = CalendricalHelper.julianDay(today.year, today.month, today.day);
 
-    calendar.add(Calendar.DATE, 1);
-    final Date tomorrow = calendar.getTime();
-
-    calendar.add(Calendar.DATE, -2);
-    final Date yesterday = calendar.getTime();
-
-    this.prevSolar = new SolarCoordinates(CalendricalHelper.julianDay(yesterday));
-    this.solar = new SolarCoordinates(CalendricalHelper.julianDay(today));
-    this.nextSolar = new SolarCoordinates(CalendricalHelper.julianDay(tomorrow));
+    this.prevSolar = new SolarCoordinates(julianDate - 1);
+    this.solar = new SolarCoordinates(julianDate);
+    this.nextSolar = new SolarCoordinates(julianDate + 1);
 
     this.approximateTransit = Astronomical.approximateTransit(coordinates.longitude,
         solar.apparentSiderealTime, solar.rightAscension);

--- a/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
+++ b/adhan/src/test/java/com/batoulapps/adhan/internal/AstronomicalTest.java
@@ -3,6 +3,7 @@ package com.batoulapps.adhan.internal;
 import com.batoulapps.adhan.Coordinates;
 import com.batoulapps.adhan.data.CalendarUtil;
 import com.batoulapps.adhan.data.TimeComponents;
+import com.batoulapps.adhan.data.DateComponents;
 
 import org.junit.Test;
 
@@ -159,7 +160,7 @@ public class AstronomicalTest {
      */
 
     final Coordinates coordinates = new Coordinates(35 + 47.0/60.0, -78 - 39.0/60.0);
-    final SolarTime solar = new SolarTime(TestUtils.makeDate(2015, 7, 12), coordinates);
+    final SolarTime solar = new SolarTime(new DateComponents(2015, 7, 12), coordinates);
 
     final double transit = solar.transit;
     final double sunrise = solar.sunrise;
@@ -190,8 +191,8 @@ public class AstronomicalTest {
     // generated from http://aa.usno.navy.mil/data/docs/RS_OneYear.php for KUKUIHAELE, HAWAII
     final Coordinates coordinates = new Coordinates(
         /* latitude */ 20 + 7.0/60.0, /* longitude */ -155.0 - 34.0/60.0);
-    final SolarTime day1solar = new SolarTime(TestUtils.makeDate(2015, 4, /* day */ 2), coordinates);
-    final SolarTime day2solar = new SolarTime(TestUtils.makeDate(2015, 4, 3), coordinates);
+    final SolarTime day1solar = new SolarTime(new DateComponents(2015, 4, /* day */ 2), coordinates);
+    final SolarTime day2solar = new SolarTime(new DateComponents(2015, 4, 3), coordinates);
 
     final double day1 = day1solar.sunrise;
     final double day2 = day2solar.sunrise;

--- a/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
+++ b/adhan/src/test/java/com/batoulapps/adhan/internal/TestUtils.java
@@ -43,11 +43,11 @@ public class TestUtils {
     return CalendarUtil.add(date, seconds, Calendar.SECOND);
   }
 
-  static Date makeDateWithOffset(int year, int month, int day, int offset, int unit) {
+  static DateComponents makeDateWithOffset(int year, int month, int day, int offset, int unit) {
     Calendar calendar = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
     //noinspection MagicConstant
     calendar.set(year, month - 1, day);
     calendar.add(unit, offset);
-    return calendar.getTime();
+    return DateComponents.fromUTC(calendar.getTime());
   }
 }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -36,6 +36,15 @@
                     <arguments/>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
I noticed that in `PrayerTimes.java` the function `public PrayerTimes(Coordinates coordinates, DateComponents date, CalculationParameters params)` constructs a `Date` object by calling `resolveTime` which does this using a UTC calendar. Then in `private PrayerTimes(Coordinates coordinates, Date date, CalculationParameters parameters)` the date is turned back into components using `DateComponents.from(date)` but this assumes the local timezone. This doesn't work when it's run on a machine that isn't in UTC. To fix this I added `fromUTC` function to `DateComponents` so that the date components are correctly reconstructed.