### PR TITLE
DateComponents: Support LocalDate

### DIFF
--- a/adhan/src/main/java/com/batoulapps/adhan/data/DateComponents.java
+++ b/adhan/src/main/java/com/batoulapps/adhan/data/DateComponents.java
@@ -1,5 +1,6 @@
 package com.batoulapps.adhan.data;
 
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -20,6 +21,10 @@ public class DateComponents {
     calendar.setTime(date);
     return new DateComponents(calendar.get(Calendar.YEAR),
         calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH));
+  }
+
+  public static DateComponents from(LocalDate date){
+    return new DateComponents(date.getYear(),date.getMonthValue(),date.getDayOfMonth());
   }
 
   public DateComponents(int year, int month, int day) {


### PR DESCRIPTION
An app that I was working on used `LocalDate` for most date operations. Converting from `LocalDate` to `Date` to use this library caused the times to come out wrong. This PR aims to allow you to construct a `DateComponents` object using `LocalDate`