### PR TITLE
Fix Sunrise/Sunset issues near International Date Line

### DIFF
--- a/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/PrayerTimes.kt
+++ b/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/PrayerTimes.kt
@@ -87,7 +87,10 @@ data class PrayerTimes(
       }
 
       // get night length
-      val tomorrowSunrise = tomorrowSunriseComponents.dateComponents(tomorrow)
+      var tomorrowSunrise = tomorrowSunriseComponents.dateComponents(tomorrow)
+      if (tomorrowSunrise.before(sunsetComponents)) {
+        tomorrowSunrise = add(tomorrowSunrise, 1, DateTimeUnit.DAY)
+      }
       val night = tomorrowSunrise.toInstant(TimeZone.UTC).toEpochMilliseconds() -
           sunsetComponents.toInstant(TimeZone.UTC).toEpochMilliseconds()
 
@@ -124,7 +127,7 @@ data class PrayerTimes(
         )
       }
 
-      if (tempFajr == null || tempFajr.before(safeFajr)) {
+      if (tempFajr == null || tempFajr.before(safeFajr) || tempFajr.after(sunriseComponents)) {
         tempFajr = safeFajr
       }
 
@@ -157,7 +160,7 @@ data class PrayerTimes(
           add(sunsetComponents, nightFraction.toInt(), DateTimeUnit.SECOND)
         }
 
-        if (tempIsha == null || tempIsha.after(safeIsha)) {
+        if (tempIsha == null || tempIsha.after(safeIsha) || tempIsha.before(sunsetComponents)) {
           tempIsha = safeIsha
         }
       }

--- a/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
+++ b/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
@@ -470,5 +471,27 @@ class PrayerTimesTest {
     assertEquals("04:26 PM", stringifyAtTimezone(fourthPrayerTimes.asr, zoneId))
     assertEquals("06:13 PM", stringifyAtTimezone(fourthPrayerTimes.maghrib, zoneId))
     assertEquals("07:37 PM", stringifyAtTimezone(fourthPrayerTimes.isha, zoneId))
+  }
+
+  @Test
+  fun testPrayerTimesProblems_fajr_after_sunrise__and_isha_before_maghrib1() {
+    checkPrayersOrder(DateComponents(2025, 12, 1), Coordinates(42.74674252600066, 177.2401196144623))
+  }
+
+  @Test
+  fun testPrayerTimesProblems_fajr_after_sunrise__and_isha_before_maghrib2() {
+    checkPrayersOrder(DateComponents(2025, 12, 1), Coordinates(47.082209457885355, 177.24642294208638))
+  }
+
+  private fun checkPrayersOrder(date: DateComponents, coordinates: Coordinates) {
+    val params = MUSLIM_WORLD_LEAGUE.parameters.copy(
+      madhab = Madhab.SHAFI,
+      highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE)
+    val prayerTimes = PrayerTimes(coordinates, date, params)
+    assertTrue(prayerTimes.fajr.epochSeconds < prayerTimes.sunrise.epochSeconds);
+    assertTrue(prayerTimes.sunrise.epochSeconds < prayerTimes.dhuhr.epochSeconds);
+    assertTrue(prayerTimes.dhuhr.epochSeconds < prayerTimes.asr.epochSeconds);
+    assertTrue(prayerTimes.asr.epochSeconds < prayerTimes.maghrib.epochSeconds);
+    assertTrue(prayerTimes.maghrib.epochSeconds < prayerTimes.isha.epochSeconds);
   }
 }


### PR DESCRIPTION
Prayer time calculations near the International Date Line could produce invalid Fajr/Isha ordering because the next sunrise used for night length could resolve before the current sunset in UTC.

Normalize the computed next sunrise by advancing it one day when it falls before sunset, keeping night length positive across the date boundary.

Also guard Fajr and Isha against raw solar-angle results that land on the wrong side of sunrise/sunset. In those cases, use the existing safe twilight bounds so prayer ordering remains valid without changing the calculation method’s fallback policy.

Fixes #78