### PR TITLE
Fix for an edge case that occurs around the international date line

### DIFF
--- a/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
+++ b/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
@@ -193,11 +193,11 @@ internal object Astronomical {
   }
 
   /**
-   * Return the approximate transite
+   * Return the approximate transit
    * @param L the longitude
    * @param Θ0 the sidereal time
    * @param α2 the right ascension
-   * @return the approximate transite
+   * @return the approximate transit
    */
   fun approximateTransit(L: Double, Θ0: Double, α2: Double): Double {
     /* Equation from page Astronomical Algorithms 102 */

--- a/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
+++ b/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
@@ -202,7 +202,17 @@ internal object Astronomical {
   fun approximateTransit(L: Double, Θ0: Double, α2: Double): Double {
     /* Equation from page Astronomical Algorithms 102 */
     val Lw = L * -1
-    return normalizeWithBound((α2 + Lw - Θ0) / 360, 1.0)
+    val m0 = normalizeWithBound((α2 + Lw - Θ0) / 360, 1.0)
+    // For locations near the International Date Line, normalizeWithBound can produce
+    // an m0 for the wrong calendar date.  We detect this by comparing m0 to a
+    // generalized transit time based on the longitude If they differ by more than
+    // half a day, m0 is off by one cycle and we adjust in the correct direction.
+    val expectedTransit = normalizeWithBound((12.0 - L / 15.0) / 24.0, 1.0)
+    return when {
+      m0 - expectedTransit > 0.5 -> m0 - 1.0
+      expectedTransit - m0 > 0.5 -> m0 + 1.0
+      else -> m0
+    }
   }
 
   /**

--- a/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
+++ b/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
@@ -470,5 +471,27 @@ class PrayerTimesTest {
     assertEquals("04:26 PM", stringifyAtTimezone(fourthPrayerTimes.asr, zoneId))
     assertEquals("06:13 PM", stringifyAtTimezone(fourthPrayerTimes.maghrib, zoneId))
     assertEquals("07:37 PM", stringifyAtTimezone(fourthPrayerTimes.isha, zoneId))
+  }
+
+  @Test
+  fun testPrayerTimesProblems_fajr_after_sunrise__and_isha_before_maghrib1() {
+    checkPrayersOrder(DateComponents(2025, 12, 1), Coordinates(42.74674252600066, 177.2401196144623))
+  }
+
+  @Test
+  fun testPrayerTimesProblems_fajr_after_sunrise__and_isha_before_maghrib2() {
+    checkPrayersOrder(DateComponents(2025, 12, 1), Coordinates(47.082209457885355, 177.24642294208638))
+  }
+
+  private fun checkPrayersOrder(date: DateComponents, coordinates: Coordinates) {
+    val params = MUSLIM_WORLD_LEAGUE.parameters.copy(
+      madhab = Madhab.SHAFI,
+      highLatitudeRule = HighLatitudeRule.TWILIGHT_ANGLE)
+    val prayerTimes = PrayerTimes(coordinates, date, params)
+    assertTrue(prayerTimes.fajr.epochSeconds < prayerTimes.sunrise.epochSeconds);
+    assertTrue(prayerTimes.sunrise.epochSeconds < prayerTimes.dhuhr.epochSeconds);
+    assertTrue(prayerTimes.dhuhr.epochSeconds < prayerTimes.asr.epochSeconds);
+    assertTrue(prayerTimes.asr.epochSeconds < prayerTimes.maghrib.epochSeconds);
+    assertTrue(prayerTimes.maghrib.epochSeconds < prayerTimes.isha.epochSeconds);
   }
 }

--- a/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/internal/AstronomicalTest.kt
+++ b/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/internal/AstronomicalTest.kt
@@ -121,6 +121,44 @@ class AstronomicalTest {
   }
 
   @Test
+  fun testApproximateTransitNearDateLine() {
+    // On Dec 1, 2025 for a location at longitude ~177°E, the solar transit falls just
+    // before UTC midnight. The raw (alpha2 + Lw - theta0) / 360 value is a tiny negative
+    // number (~-0.000028), which normalizeWithBound wraps to ~0.9999 — placing the transit
+    // at 23:59 UTC (local noon the *next* local day) instead of ~00:00 UTC (local noon on
+    // the requested date). The fix detects this by comparing against the expected transit
+    // for the longitude and adjusting by one cycle when they differ by more than half a day.
+    val jd = julianDay(2025, 12, 1)
+    val solar = SolarCoordinates(jd)
+    val longitude = 177.2401196144623
+    val m0 = approximateTransit(longitude, solar.apparentSiderealTime, solar.rightAscension)
+    // After fix: m0 should be near 0 (transit just before/after UTC midnight = local noon Dec 1),
+    // not near 1 (which would be 23:59 UTC = local noon Dec 2).
+    assertTrue(abs(m0) < 0.1, "approximateTransit near date line returned $m0, expected value near 0")
+  }
+
+  @Test
+  fun testSolarTimeContinuityNearDateLine() {
+    // Near the International Date Line, the solar transit crosses UTC midnight on certain dates,
+    // causing approximateTransit to wrap to the wrong cycle without the fix. This produces ~24h
+    // jumps in raw transit/sunrise/sunset values between consecutive days (e.g. Dec 1 → Dec 2,
+    // 2025 at this longitude), which breaks night-duration and safe fajr/isha calculations.
+    lateinit var previousTime: SolarTime
+    val coordinates = Coordinates(42.74674252600066, 177.2401196144623)
+    for (i in 0..364) {
+      val time = SolarTime(
+        TestUtils.makeDateWithOffset(2025, 11, 1, i, DateTimeUnit.DAY), coordinates
+      )
+      if (i > 0) {
+        assertTrue(abs(time.transit - previousTime.transit) < (1.0 / 60.0))
+        assertTrue(abs(time.sunrise - previousTime.sunrise) < (2.0 / 60.0))
+        assertTrue(abs(time.sunset - previousTime.sunset) < (2.0 / 60.0))
+      }
+      previousTime = time
+    }
+  }
+
+  @Test
   fun testAltitudeOfCelestialBody() {
     val φ = 38 + 55 / 60.0 + 17.0 / 3600
     val δ = -6 - 43 / 60.0 - 11.61 / 3600


### PR DESCRIPTION
While reviewing #84 I managed to trace the issue back to an edge case in how calculate approximateTransit. Essentially we don't expect transit (noon) to ever be in a different UTC day, however this can happen near the international date line. The fix involves correcting the returned value of approximate transit if the longitude based transit differs by more than 12 hrs from the approximate transmit. 

Fixes #78 