### PR TITLE
fix(asr calculation): polar circle safeguards

### DIFF
--- a/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
+++ b/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/Astronomical.kt
@@ -4,6 +4,7 @@ import com.batoulapps.adhan2.Coordinates
 import com.batoulapps.adhan2.internal.DoubleUtil.closestAngle
 import com.batoulapps.adhan2.internal.DoubleUtil.normalizeWithBound
 import com.batoulapps.adhan2.internal.DoubleUtil.unwindAngle
+import kotlin.math.abs
 import kotlin.math.acos
 import kotlin.math.asin
 import kotlin.math.cos
@@ -265,29 +266,45 @@ internal object Astronomical {
     m0: Double, h0: Double, coordinates: Coordinates, afterTransit: Boolean,
     Θ0: Double, α2: Double, α1: Double, α3: Double, δ2: Double, δ1: Double, δ3: Double
   ): Double {
-    /* Equation from page Astronomical Algorithms 102 */
+    /* Equation from Astronomical Algorithms page 102 */
     val Lw = coordinates.longitude * -1
     val term1 = sin(h0.toRadians()) - sin(coordinates.latitude.toRadians()) * sin(δ2.toRadians())
     val term2 = cos(coordinates.latitude.toRadians()) * cos(δ2.toRadians())
     val H0: Double = acos(term1 / term2).toDegrees()
-    val m = if (afterTransit) m0 + H0 / 360 else m0 - H0 / 360
-    val θ = unwindAngle(Θ0 + 360.985647 * m)
-    val α = unwindAngle(
-      interpolateAngles( /* value */
-        α2,  /* previousValue */α1,  /* nextValue */α3,  /* factor */m
+    var m = if (afterTransit) m0 + H0 / 360 else m0 - H0 / 360
+
+    // Astronomical Algorithms page 103 notes that the correction value of Δm
+    // should be ±0.01 and to recalculate with the corrected m value if needed.
+    // Iteration is capped at 10 to account for situations where convergence doesn't occur.
+    for (i in 0 until 10) {
+      val θ = unwindAngle(Θ0 + 360.985647 * m)
+      val α = unwindAngle(
+        interpolateAngles( /* value */
+          α2,  /* previousValue */α1,  /* nextValue */α3,  /* factor */m
+        )
       )
-    )
-    val δ = interpolate( /* value */δ2,  /* previousValue */δ1,  /* nextValue */
-      δ3,  /* factor */m
-    )
-    val H = θ - Lw - α
-    val h = altitudeOfCelestialBody( /* observerLatitude */coordinates.latitude,  /* declination */
-      δ,  /* localHourAngle */H
-    )
-    val term3 = h - h0
-    val term4 = 360 * cos(δ.toRadians()) * cos(coordinates.latitude.toRadians()) * sin(H.toRadians())
-    val Δm = term3 / term4
-    return (m + Δm) * 24
+      val δ = interpolate( /* value */δ2,  /* previousValue */δ1,  /* nextValue */
+        δ3,  /* factor */m
+      )
+      val H = θ - Lw - α
+      val h = altitudeOfCelestialBody( /* observerLatitude */coordinates.latitude,  /* declination */
+        δ,  /* localHourAngle */H
+      )
+      val ΔmDenominator = 360 * cos(δ.toRadians()) * cos(coordinates.latitude.toRadians()) * sin(H.toRadians())
+      if (ΔmDenominator == 0.0) {
+        return Double.NaN
+      }
+
+      val Δm = (h - h0) / ΔmDenominator
+      m += Δm
+
+      // Stop iteration once the correction value of Δm is ±0.01
+      if (abs(Δm) <= 0.01) {
+        break
+      }
+    }
+
+    return m * 24
   }
 
   /**

--- a/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/SolarTime.kt
+++ b/adhan/src/commonMain/kotlin/com/batoulapps/adhan2/internal/SolarTime.kt
@@ -2,6 +2,7 @@ package com.batoulapps.adhan2.internal
 
 import com.batoulapps.adhan2.Coordinates
 import com.batoulapps.adhan2.data.DateComponents
+import com.batoulapps.adhan2.internal.Astronomical.altitudeOfCelestialBody
 import com.batoulapps.adhan2.internal.Astronomical.approximateTransit
 import com.batoulapps.adhan2.internal.Astronomical.correctedHourAngle
 import com.batoulapps.adhan2.internal.Astronomical.correctedTransit
@@ -61,11 +62,23 @@ class SolarTime(date: DateComponents, coordinates: Coordinates) {
 
   // hours from transit
   fun afternoon(shadowLength: ShadowLength): Double {
-    // TODO (from Swift version) source shadow angle calculation
     val tangent: Double = abs(observer.latitude - solar.declination)
-    val inverse: Double =
-      shadowLength.shadowLength + tan(tangent.toRadians())
+    val inverse: Double = shadowLength.shadowLength + tan(tangent.toRadians())
     val angle: Double = atan(1.0 / inverse).toDegrees()
+
+    // A valid Asr time requires the sun's disc is fully above the horizon.
+    // The calculated angle for Asr is based on the midpoint of the sun's disc.
+    val solarAngularDiameter = 32.0 / 60.0
+    if (angle <= solarAngularDiameter / 2) {
+      return Double.NaN
+    }
+
+    // Confirm the sun's maximum altitude on this day can reach the Asr angle
+    val maxAltitude = altitudeOfCelestialBody(observer.latitude, solar.declination, 0.0)
+    if (maxAltitude < angle) {
+      return Double.NaN
+    }
+
     return timeForSolarAngle(angle, true)
   }
 }

--- a/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
+++ b/adhan/src/commonTest/kotlin/com/batoulapps/adhan2/PrayerTimesTest.kt
@@ -474,6 +474,31 @@ class PrayerTimesTest {
   }
 
   @Test
+  fun testAsrNilWhenSunCannotReachRequiredAltitude() {
+    // At 67N in early January the sun's max altitude stays below the Asr angle
+    val coordinates = Coordinates(67.37800510772394, -67.26246475893095)
+    val date = DateComponents(2026, 1, 5)
+    val params = MUSLIM_WORLD_LEAGUE.parameters
+    assertFailsWith<IllegalStateException> {
+      PrayerTimes(coordinates, date, params)
+    }
+  }
+
+  @Test
+  fun testPrayerTimesOrderedWhenSunBarelyReachesAsrAltitude() {
+    // On Jan 8 the sun just clears the Asr threshold; times should be in order
+    val coordinates = Coordinates(67.37800510772394, -67.26246475893095)
+    val date = DateComponents(2026, 1, 8)
+    val params = MUSLIM_WORLD_LEAGUE.parameters
+    val p = PrayerTimes(coordinates, date, params)
+    assertTrue(p.fajr.epochSeconds < p.sunrise.epochSeconds)
+    assertTrue(p.sunrise.epochSeconds < p.dhuhr.epochSeconds)
+    assertTrue(p.dhuhr.epochSeconds < p.asr.epochSeconds)
+    assertTrue(p.asr.epochSeconds < p.maghrib.epochSeconds)
+    assertTrue(p.maghrib.epochSeconds < p.isha.epochSeconds)
+  }
+
+  @Test
   fun testPrayerTimesProblems_fajr_after_sunrise__and_isha_before_maghrib1() {
     checkPrayersOrder(DateComponents(2025, 12, 1), Coordinates(42.74674252600066, 177.2401196144623))
   }


### PR DESCRIPTION
Added safeguard requirements to the asr calculation function for locations in the polar circle where the sun barely rises but never leaves the horizon.

Also added in the recommended iteration of delta m in the corrected hour angle function as described in the Astronomical Algorithms text.

Fixes #86 